### PR TITLE
fix: types for handlers

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ In your test, you can wrap your MSW handlers with `mockHandler`:
 
 ```js
 import { rest } from "msw";
-import { mockHandler, server } from "msw-expect";
+import { DefaultResponseResolver, mockHandler, server } from "msw-expect";
 
 import { myMswHandler } from "./myMswHandler";
 import { fetchFlavor } from "./fetchFlavor";
@@ -36,7 +36,7 @@ import { fetchFlavor } from "./fetchFlavor";
 test("fetch flavor called with flavor param", async () => {
   const handler = mockHandler(myMswHandler);
 
-  server.use(rest.get("https://api.example.com/flavors", handler));
+  server.use(rest.get("https://api.example.com/flavors", handler as DefaultResponseResolver));
 
   await fetchFlavor();
 
@@ -57,7 +57,7 @@ const handler = mockHandler();
 You can also assert on request URL, body, headers, etc., with `getRequest()` as well as response status, body, etc., with `getResponse()`:
 
 ```js
-server.use(rest.post("https://api.example.com/flavors", handler));
+server.use(rest.post("https://api.example.com/flavors", handler as DefaultResponseResolver));
 
 await postFlavor();
 

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ module.exports = {
 
 In your test, you can wrap your MSW handlers with `mockHandler`:
 
-```js
+```ts
 import { rest } from "msw";
 import { mockHandler, server } from "msw-expect";
 
@@ -36,7 +36,13 @@ import { fetchFlavor } from "./fetchFlavor";
 test("fetch flavor called with flavor param", async () => {
   const handler = mockHandler(myMswHandler);
 
-  server.use(rest.get("https://api.example.com/flavors", handler as typeof myMswHandler));
+  server.use(
+    rest.get(
+      "https://api.example.com/flavors",
+      // Only use the "as..." part if you're using TypeScript.
+      handler as typeof myMswHandler
+    )
+  );
 
   await fetchFlavor();
 
@@ -50,14 +56,31 @@ test("fetch flavor called with flavor param", async () => {
 
 Or, if you don't need to mock the response, you don't need to provide a handler to wrap (the default just responds with 200):
 
-```js
+```ts
+// Only import `DefaultResponseResolver` if you're using TypeScript.
+import { DefaultResponseResolver } from "msw-expect";
+
 const handler = mockHandler();
+
+server.use(
+  rest.post(
+    "https://api.example.com/flavors",
+    // Only use the "as..." part if you're using TypeScript.
+    handler as DefaultResponseResolver
+  )
+);
 ```
 
 You can also assert on request URL, body, headers, etc., with `getRequest()` as well as response status, body, etc., with `getResponse()`:
 
-```js
-server.use(rest.post("https://api.example.com/flavors", handler as typeof myMswHandler));
+```ts
+server.use(
+  rest.post(
+    "https://api.example.com/flavors",
+    // Only use the "as..." part if you're using TypeScript.
+    handler as typeof myMswHandler
+  )
+);
 
 await postFlavor();
 
@@ -83,7 +106,7 @@ You can use any of the [Jest assertion utilities](https://jestjs.io/docs/en/expe
 
 To assert multiple requests and responses, use `getRequest(index)` and `getResponse(index)`:
 
-```js
+```ts
 // Assert on the 2nd request (1st index):
 
 expect(handler.getRequest(1)).toMatchObject({
@@ -101,7 +124,7 @@ expect(handler.getResponse(2)).toMatchObject({
 
 To assert count of requests, use `getRequests()`:
 
-```js
+```ts
 expect(handler.getRequests()).toHaveLength(3);
 ```
 
@@ -111,7 +134,7 @@ If you prefer to configure your server manually, you do not need to use `msw-exp
 
 Instead, you can configure a vanilla MSW server yourself:
 
-```js
+```ts
 import { setupServer } from "msw/node";
 
 export const server = setupServer();

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ In your test, you can wrap your MSW handlers with `mockHandler`:
 
 ```js
 import { rest } from "msw";
-import { DefaultResponseResolver, mockHandler, server } from "msw-expect";
+import { mockHandler, server } from "msw-expect";
 
 import { myMswHandler } from "./myMswHandler";
 import { fetchFlavor } from "./fetchFlavor";
@@ -36,7 +36,7 @@ import { fetchFlavor } from "./fetchFlavor";
 test("fetch flavor called with flavor param", async () => {
   const handler = mockHandler(myMswHandler);
 
-  server.use(rest.get("https://api.example.com/flavors", handler as DefaultResponseResolver));
+  server.use(rest.get("https://api.example.com/flavors", handler as typeof myMswHandler));
 
   await fetchFlavor();
 
@@ -57,7 +57,7 @@ const handler = mockHandler();
 You can also assert on request URL, body, headers, etc., with `getRequest()` as well as response status, body, etc., with `getResponse()`:
 
 ```js
-server.use(rest.post("https://api.example.com/flavors", handler as DefaultResponseResolver));
+server.use(rest.post("https://api.example.com/flavors", handler as typeof myMswHandler));
 
 await postFlavor();
 

--- a/src/mockHandler.ts
+++ b/src/mockHandler.ts
@@ -1,10 +1,9 @@
-import { MockedRequest, ResponseResolver, rest } from "msw";
+import { rest } from "msw";
 
-type ContextType = Parameters<Parameters<typeof rest.get>[1]>[2];
+export type DefaultResponseResolver = Parameters<typeof rest.post>[1];
 
 export const mockHandler = (
-  handler: ResponseResolver<MockedRequest, ContextType> = (_req, res, ctx) =>
-    res(ctx.status(200))
+  handler: DefaultResponseResolver = (_req, res, ctx) => res(ctx.status(200))
 ) => {
   let requests: {}[] = [];
   let responses: ({} | undefined)[] = [];
@@ -15,7 +14,11 @@ export const mockHandler = (
   const getRequest = (index: number = 0) => requests[index];
   const getResponse = (index: number = 0) => responses[index];
 
-  const newHandler = async (req: MockedRequest, res: any, ctx: ContextType) => {
+  const newHandler = async (
+    req: Parameters<DefaultResponseResolver>[0],
+    res: Parameters<DefaultResponseResolver>[1],
+    ctx: Parameters<DefaultResponseResolver>[2]
+  ) => {
     const searchParamsEntries = [...(req.url?.searchParams?.entries() ?? [])];
 
     const searchParamsPairs = searchParamsEntries?.map(([name, value]) => ({

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -21,11 +21,12 @@ describe("mocks", () => {
   });
 
   test("expect request with response", async () => {
-    const handler = mockHandler((_req, res, ctx) =>
-      res(ctx.status(200), ctx.json({ message: "ok" }))
-    );
+    const realHandler: DefaultResponseResolver = (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ message: "ok" }));
 
-    server.use(rest.get(/example\.com/, handler as DefaultResponseResolver));
+    const handler = mockHandler(realHandler);
+
+    server.use(rest.get(/example\.com/, handler as typeof realHandler));
 
     await doFetch();
 

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -1,12 +1,12 @@
 import { rest } from "msw";
 import { doFetch, doPost } from "./doFetch";
-import { mockHandler, server } from "..";
+import { DefaultResponseResolver, mockHandler, server } from "..";
 
 describe("mocks", () => {
   test("expect request without response", async () => {
     const handler = mockHandler();
 
-    server.use(rest.get(/example\.com/, handler));
+    server.use(rest.get(/example\.com/, handler as DefaultResponseResolver));
 
     await doFetch();
 
@@ -25,7 +25,7 @@ describe("mocks", () => {
       res(ctx.status(200), ctx.json({ message: "ok" }))
     );
 
-    server.use(rest.get(/example\.com/, handler));
+    server.use(rest.get(/example\.com/, handler as DefaultResponseResolver));
 
     await doFetch();
 
@@ -49,7 +49,7 @@ describe("mocks", () => {
   test("pairs (for duplicate keys)", async () => {
     const handler = mockHandler();
 
-    server.use(rest.get(/example\.com/, handler));
+    server.use(rest.get(/example\.com/, handler as DefaultResponseResolver));
 
     await doFetch();
 
@@ -77,7 +77,7 @@ describe("mocks", () => {
   test("expect post body", async () => {
     const handler = mockHandler();
 
-    server.use(rest.post(/example\.com/, handler));
+    server.use(rest.post(/example\.com/, handler as DefaultResponseResolver));
 
     await doPost();
 

--- a/src/test/native.test.ts
+++ b/src/test/native.test.ts
@@ -1,11 +1,13 @@
 import { rest } from "msw";
 import { server } from "..";
+import { DefaultResponseResolver } from "../mockHandler";
 import { doFetch } from "./doFetch";
 
 test("native", async () => {
-  const handler = jest.fn((_req, res, ctx) =>
-    res(ctx.status(200), ctx.json({ message: "ok" }))
-  );
+  const realHandler: DefaultResponseResolver = (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({ message: "ok" }));
+
+  const handler = jest.fn(realHandler);
 
   server.use(rest.get(/example\.com/, handler));
 


### PR DESCRIPTION
Fixing some type errors for handlers after `msw@0.31.0` changes in #3. Relates to #2.

Suggesting type assertion on handlers in docs.
